### PR TITLE
Feature/search data grid

### DIFF
--- a/src/Components/Search/index.js
+++ b/src/Components/Search/index.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Search = ({handleSearchData, search}) => {
+  return (
+    <input type="text" onChange={handleSearchData} value={search} />
+  )
+}

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -1,25 +1,26 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import completions from "Data/completions.csv";
 import production from "Data/production.csv";
-import { uid } from 'uid';
-import { Grid, GridColumn } from "@progress/kendo-react-grid";
-import '@progress/kendo-theme-default/dist/all.css';
+import { Grid } from "@progress/kendo-react-grid";
+import "@progress/kendo-theme-default/dist/all.css";
 import { UseGetData } from "Hooks/getData.js";
 import { LineChart } from "./LineChart";
-
 
 const initialDataState = {
   skip: 0,
   take: 20,
 };
 export const Home = () => {
+  const dataFileProduction = UseGetData(production);
+  const dataFileCompletions = UseGetData(completions);
   const [pageOne, setPageOne] = useState(initialDataState);
   const [pageTwo, setPageTwo] = useState(initialDataState);
-  let dataGraphOil = []
-  let dataGraphWater = []
-  let dataGraphGas = []
-  let dataGraphWaterInj = []
-  let dataGraphYear = []
+  const [search, setSearch] = useState("");
+  const dataGraphOil = [];
+  const dataGraphWater = [];
+  const dataGraphGas = [];
+  const dataGraphWaterInj = [];
+  const dataGraphYear = [];
 
   const pageChangeOne = (event) => {
     setPageOne(event.page);
@@ -27,64 +28,77 @@ export const Home = () => {
   const pageChangeTwo = (event) => {
     setPageTwo(event.page);
   };
-  
-  const addStates = () => {
-    dataFileProduction.map(data => {
-      dataGraphOil.push(Number(data.Qo))
-      dataGraphWater.push(Number(data.Qw))
-      dataGraphGas.push(Number(data.Qg))
-      dataGraphWaterInj.push(Number(data.Qs))
-      dataGraphYear.push(Number(data.Year))
-      })
-  } 
 
-  const dataFileProduction = UseGetData(production)
-  const dataFileCompletions = UseGetData(completions)
-  if (dataFileProduction.length > 0){
-    addStates()
+  const handleSearchData = (e) => {
+    setSearch(e.target.value);
+  };
+  const results = !search
+    ? dataFileCompletions
+    : dataFileCompletions.filter((dato) =>
+        dato.wellName.toLowerCase().includes(search.toLocaleLowerCase())
+      );
+  const addStates = () => {
+    dataFileProduction.map((data) => {
+      dataGraphOil.push(Number(data.Qo));
+      dataGraphWater.push(Number(data.Qw));
+      dataGraphGas.push(Number(data.Qg));
+      dataGraphWaterInj.push(Number(data.Qs));
+      dataGraphYear.push(Number(data.Year));
+    });
+  };
+
+  if (dataFileProduction.length > 0) {
+    addStates();
   }
 
-  
   return (
     <>
-    {dataFileProduction.length > 0 && dataFileProduction &&
+      {dataFileProduction.length > 0 && dataFileProduction && (
         <Grid
-        style={{
-          height: "100%"
-        }}
-        data={dataFileProduction.slice(pageOne.skip, pageOne.take + pageOne.skip)}
-        skip={pageOne.skip}
-        take={pageOne.take}
-        total={dataFileProduction.length}
-        pageable={true}
-        onPageChange={pageChangeOne}
-        >
-      {Object.keys(dataFileProduction[0]).map(e => (
-        <GridColumn key={uid()} field={e} title={e}/>
-        ))}
-    </Grid>
-      }
-    {dataFileCompletions.length > 0 && dataFileCompletions &&
+          style={{
+            height: "100%",
+          }}
+          data={dataFileProduction.slice(
+            pageOne.skip,
+            pageOne.take + pageOne.skip
+          )}
+          skip={pageOne.skip}
+          take={pageOne.take}
+          total={dataFileProduction.length}
+          pageable={true}
+          onPageChange={pageChangeOne}
+        ></Grid>
+      )}
+      <input type="text" onChange={handleSearchData} value={search} />
+      {dataFileCompletions.length > 0 && dataFileCompletions && (
         <Grid
-        style={{
-          height: "100%"
-        }}
-        data={dataFileCompletions.slice(pageTwo.skip, pageTwo.take + pageTwo.skip)}
-        skip={pageTwo.skip}
-        take={pageTwo.take}
-        total={dataFileCompletions.length}
-        pageable={true}
-        onPageChange={pageChangeTwo}
-        >
-      {Object.keys(dataFileCompletions[0]).map(e => (
-        <GridColumn key={uid()} field={e} title={e}/>
-        ))}
-    </Grid>
-      }
-      {
-        dataGraphOil.length > 0 &&
-        <LineChart year={dataGraphYear} gas={dataGraphGas} oil={dataGraphOil} water={dataGraphWater} waterInj={dataGraphWaterInj}/>
-      }
+          style={{
+            height: "100%",
+          }}
+          data={
+            results.length > 0
+              ? results.slice(pageTwo.skip, pageTwo.take + pageTwo.skip)
+              : dataFileCompletions.slice(
+                  pageTwo.skip,
+                  pageTwo.take + pageTwo.skip
+                )
+          }
+          skip={pageTwo.skip}
+          take={pageTwo.take}
+          total={results.length > 0 ? results.length : dataFileCompletions.length}
+          pageable={true}
+          onPageChange={pageChangeTwo}
+        ></Grid>
+      )}
+      {dataGraphOil.length > 0 && (
+        <LineChart
+          year={dataGraphYear}
+          gas={dataGraphGas}
+          oil={dataGraphOil}
+          water={dataGraphWater}
+          waterInj={dataGraphWaterInj}
+        />
+      )}
     </>
   );
 };

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -15,10 +15,6 @@ const initialDataState = {
 export const Home = () => {
   const [pageOne, setPageOne] = useState(initialDataState);
   const [pageTwo, setPageTwo] = useState(initialDataState);
-  const [oil, setOil] = useState([])
-  const [water, setWater] = useState([])
-  const [gas, setGas] = useState([])
-  const [waterInj, setWaterInj] = useState([])
   let dataGraphOil = []
   let dataGraphWater = []
   let dataGraphGas = []
@@ -44,15 +40,10 @@ export const Home = () => {
 
   const dataFileProduction = UseGetData(production)
   const dataFileCompletions = UseGetData(completions)
-  if (dataFileProduction.length > 0)
-  addStates()
-  {/* 
-    setOil(dataFileProduction.map(water => water.Qo))
-    setWater(dataFileProduction.map(water => water.Qw))
-    setGas(dataFileProduction.map(water => water.Qg))
-    setWaterInj(dataFileProduction.map(water => water.Qs)) */
-
+  if (dataFileProduction.length > 0){
+    addStates()
   }
+
   
   return (
     <>

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -5,6 +5,7 @@ import { Grid } from "@progress/kendo-react-grid";
 import "@progress/kendo-theme-default/dist/all.css";
 import { UseGetData } from "Hooks/getData.js";
 import { LineChart } from "./LineChart";
+import { Search } from "./Search";
 
 const initialDataState = {
   skip: 0,
@@ -69,7 +70,7 @@ export const Home = () => {
           onPageChange={pageChangeOne}
         ></Grid>
       )}
-      <input type="text" onChange={handleSearchData} value={search} />
+      <Search handleSearchData={handleSearchData} search={search} />
       {dataFileCompletions.length > 0 && dataFileCompletions && (
         <Grid
           style={{


### PR DESCRIPTION
Step Three - Searching the data in the files
For this step, you will provide the user with the ability to search the completion data grid for a specific wellName; the search should give the user the option to use partial names.

Example: If the user types PLMS in the search input, the page will filter to only show wells that start with PLMS.

Add a search input box to the page.

The search functionality may be triggered by the user's typing or hitting a search button. It needs to do one but does not need to do both.

The grid and visualization should filter only to show the data associated with the results from the search input.